### PR TITLE
Add server remote access/static IP setup docs (#9)

### DIFF
--- a/server/docs/REMOTE_ACCESS_SETUP.md
+++ b/server/docs/REMOTE_ACCESS_SETUP.md
@@ -1,0 +1,70 @@
+# Server Static Configuration for Remote Access (Ticket #9)
+
+## Goal
+Configure a stable static IP + secure remote access (SSH) so students can reliably connect to the Avatar server for benchmarking and training tasks.
+
+> ⚠️ Note: This document intentionally avoids sensitive details (no real IPs, usernames, private keys, or internal hostnames).
+
+---
+
+## 1) Static IP (Netplan)
+**Location:** `/etc/netplan/01-static-ip.yaml`  
+**Template in repo:** `server/network/01-netplan-static-ip.template.yaml`
+
+Steps (run on server):
+1. Identify active interface:
+   - `ip a`
+   - Example interface name: `eno1` or `enp0s31f6`
+2. Copy template → netplan path and update:
+   - IP address
+   - gateway
+   - DNS
+3. Apply:
+   - `sudo netplan generate`
+   - `sudo netplan apply`
+4. Verify:
+   - `ip a`
+   - `ip route`
+   - `resolvectl status` (or check DNS resolution)
+
+---
+
+## 2) SSH Setup + Hardening
+**Reference in repo:** `server/ssh/sshd_hardening.md`
+
+Minimum requirements:
+- SSH enabled
+- Key-based auth for students
+- Disable password auth after keys confirmed working
+
+Verification:
+- From an external machine: `ssh -i <keyfile> user@<server-ip>`
+
+---
+
+## 3) Firewall Rules
+**Reference in repo:** `server/firewall/ufw_rules.md`
+
+Minimum:
+- allow SSH (port 22 or your custom port)
+- deny everything else by default
+- allow only what you need later (RDP, app ports, etc.)
+
+---
+
+## 4) External Connectivity Test
+Test from outside the network:
+- SSH works over the static IP (or public-facing NAT if used)
+- Connection is stable and repeatable
+
+Checklist:
+- [ ] SSH key auth works
+- [ ] Password auth disabled (after verification)
+- [ ] Firewall active and minimal
+- [ ] Static IP persists after reboot
+
+---
+
+## 5) Notes / Next Steps
+- If public access is required, coordinate NAT/port forwarding and document it separately (without exposing sensitive values).
+- Consider adding Fail2Ban and rate limiting if exposed publicly.

--- a/server/firewall/ufw_rules.md
+++ b/server/firewall/ufw_rules.md
@@ -1,0 +1,18 @@
+# Firewall Rules (UFW) - Ticket #9
+
+## Baseline setup
+1) Enable UFW:
+- `sudo ufw default deny incoming`
+- `sudo ufw default allow outgoing`
+
+2) Allow SSH:
+- `sudo ufw allow 22/tcp`
+  - If using a custom SSH port: replace `22`
+
+3) Enable:
+- `sudo ufw enable`
+- `sudo ufw status verbose`
+
+## Notes
+- Keep rules minimal.
+- Only open additional ports if required (document the reason and port).

--- a/server/network/01-netplan-static-ip.template.yaml
+++ b/server/network/01-netplan-static-ip.template.yaml
@@ -1,0 +1,18 @@
+# Netplan static IP template (Ticket #9)
+# Copy to: /etc/netplan/01-static-ip.yaml and replace placeholders safely.
+
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    <INTERFACE_NAME>:
+      dhcp4: false
+      addresses:
+        - <STATIC_IP>/<CIDR>   # example: 192.168.1.50/24
+      routes:
+        - to: default
+          via: <GATEWAY_IP>    # example: 192.168.1.1
+      nameservers:
+        addresses:
+          - <DNS_1>            # example: 1.1.1.1
+          - <DNS_2>            # example: 8.8.8.8

--- a/server/ssh/sshd_hardening.md
+++ b/server/ssh/sshd_hardening.md
@@ -1,0 +1,39 @@
+# SSH Hardening Notes (Ticket #9)
+
+## Recommended baseline
+- Use SSH keys (required)
+- Disable password auth after verifying keys work
+- Optional: change SSH port only if your org wants it (security-by-obscurity is not a replacement)
+
+---
+
+## Key-based login
+1. Create user (if needed):
+   - `sudo adduser <student_user>`
+2. Add their public key:
+   - `sudo mkdir -p /home/<student_user>/.ssh`
+   - `sudo nano /home/<student_user>/.ssh/authorized_keys`
+   - `sudo chmod 700 /home/<student_user>/.ssh`
+   - `sudo chmod 600 /home/<student_user>/.ssh/authorized_keys`
+   - `sudo chown -R <student_user>:<student_user> /home/<student_user>/.ssh`
+
+---
+
+## sshd_config changes (example)
+File: `/etc/ssh/sshd_config`
+
+Recommended:
+- `PubkeyAuthentication yes`
+- `PasswordAuthentication no`  (after confirming key login works)
+- `PermitRootLogin no`
+- `X11Forwarding no` (unless needed)
+- `AllowUsers <student_user> <admin_user>` (optional allowlist)
+
+Apply:
+- `sudo systemctl restart ssh`
+- `sudo systemctl status ssh`
+
+---
+
+## Validate from external machine
+- `ssh -i <keyfile> <student_user>@<server-ip>`


### PR DESCRIPTION
**Summary**

Adds documentation + templates for configuring the Avatar server with:

- a static IP (Netplan),
- hardened SSH (key-based auth),
- and firewall rules (UFW)

This supports reliable remote access for students running benchmarking/training workloads.

**What’s included**

- server/docs/REMOTE_ACCESS_SETUP.md
- end-to-end steps for static IP + SSH access + validation checklist
- server/network/01-netplan-static-ip.template.yaml
- template netplan config using placeholders (no real IPs)
- server/ssh/sshd_hardening.md
- SSH hardening notes (disable password auth after keys confirmed)
- server/firewall/ufw_rules.md
- recommended UFW rules + verification commands

**Security / Sensitive Info**

✅ Uses placeholders only (<server-ip>, <student_user>, <keyfile>)
✅ No real IPs, usernames, hostnames, passwords, or private keys included

**How to validate (high-level)**

- Review docs/templates for completeness and placeholder usage
- On target server (admin-only):
- apply netplan config + confirm IP persists after reboot
- confirm SSH key auth works
- enable UFW rules and verify external connectivity

**Ticket**

Closes / relates to: #9

**Notes**

This PR is documentation/templates only (no server-side changes executed in repo).