### PR TITLE
reupload shuffler-freeze-fix

### DIFF
--- a/FileShuffler.qml
+++ b/FileShuffler.qml
@@ -38,6 +38,13 @@ Rectangle {
             radius: 10
             color: "#202846"    // dark blue header
 
+            Connections { 
+                target: fileShufflerGui
+                    function onShuffleComplete(output) {
+                        fileShufflerView.runLog += output + "\n"
+                        fileShufflerView.ranShuffle = true
+                    }
+            }
             ColumnLayout {
                 anchors.fill: parent
                 anchors.margins: 14
@@ -282,9 +289,8 @@ Rectangle {
 
         onAccepted: {
             console.log("Selected folder:", fileShufflerDialog.folder)
-            var output = fileShufflerGui.run_file_shuffler_program(fileShufflerDialog.folder)
-            fileShufflerView.runLog += output + "\n"
-            fileShufflerView.ranShuffle = true
+            fileShufflerView.runLog = "Running File Shuffler...\n"
+            fileShufflerGui.run_file_shuffler_program(fileShufflerDialog.folder)
         }
 
         onRejected: {

--- a/shuffler_api.py
+++ b/shuffler_api.py
@@ -14,16 +14,19 @@ sys.path.append(str(Path(__file__).resolve().parent / "file-remove8channel"))
 import unifyTXT
 import run_file_shuffler
 import remove8channel
+from concurrent.futures import ThreadPoolExecutor
 
 class ShufflerAPI(QObject):
     def __init__(self):
         super().__init__()
+        self.executor = ThreadPoolExecutor(max_workers=2)
 
     @Slot()
     def launch_file_shuffler_gui(self):
         # Launch the file shuffler GUI program
         file_shuffler_path = Path(__file__).resolve().parent / "file-shuffler/file-shuffler-gui.py"
         subprocess.Popen(["python", str(file_shuffler_path)])
+    shuffleComplete = Signal(str)
 
     @Slot(str, result=str)
     def run_file_shuffler_program(self, path):
@@ -31,9 +34,17 @@ class ShufflerAPI(QObject):
         path = path.replace("file://", "")
         if path.startswith("/C:"):
             path = 'C' + path[2:]
-
-        response = run_file_shuffler.main(path)
-        return response
+            
+        future = self.executor.submit(run_file_shuffler.main, path)
+        future.add_done_callback(self.handle_result)
+       
+        return "Shuffling started..."
+    def handle_result(self, future):
+        try:
+            response = future.result()
+            self.shuffleComplete.emit(response)
+        except Exception as e:
+            self.shuffleComplete.emit(f"Error: {e}")
 
         # Adding Synthetic Data and Live Data Logic (Row 327 to 355) as part of Ticket 186
 


### PR DESCRIPTION
 
# Ticket #617 — Shuffler: Async Processing & GUI Feedback Fix

## Background

The Anonymize button in the File Shuffler tab was causing the main application window to hang,
blocking the GUI thread during the shuffler operation. The initial fix offloaded the work to a
background thread using `concurrent.futures.ThreadPoolExecutor`, which resolved the freeze but
introduced a new problem — the GUI received no feedback during or after processing. Console log
output from `run_file_shuffler.py` and `run.sh` was only visible in the terminal, never
surfacing back to the user.

## Root Cause

The QML was expecting `run_file_shuffler_program()` to return output synchronously and assign it
directly to the `runLog` display property, but once async the function returned immediately with
no meaningful output. The actual result from the background thread was only being `print()`-ed
to terminal inside `handle_result()`, never routed back to the UI.

## Fixed

- Window dialogue no longer hangs; as per splitting the two processes
  **(ShufflerGUI) & (Anonymize Button)**

- Offloaded the Shuffler Button work by creating a worker thread pool to establish the
  separation.

- Modified the QML file to accept in `Connections` (Signal) from the return statement in order
  to print the status of the `run_shuffler_program` operation.

- Display console log pipes back to the Shuffler GUI instead of just terminal.